### PR TITLE
Bug: Sort Tasks When Loading Scheduled Tasks.

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -34,15 +34,20 @@ pub async fn execute_task(task: &ScheduledTask) -> Result<(), VestaboardError> {
     // handle errors appropriately
     println!("Executing task: {:?}", task);
     let message: Vec<String> = match task.widget.as_str() {
-        "weather" => {
-            // Execute weather widget
-            println!("Executing Weather widget");
-            get_weather().await
-        }
         "text" => {
             // Execute text widget
             println!("Executing Text widget with input: {:?}", task.input);
             get_text(task.input.as_str().unwrap_or(""))
+        }
+        "file" => {
+            // Execute file widget
+            println!("Executing File widget with input: {:?}", task.input);
+            get_text_from_file(PathBuf::from(task.input.as_str().unwrap_or("")))
+        }
+        "weather" => {
+            // Execute weather widget
+            println!("Executing Weather widget");
+            get_weather().await
         }
         "sat-word" => {
             // Execute SAT word widget

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -134,12 +134,13 @@ pub fn load_schedule(path: &PathBuf) -> Result<Schedule, VestaboardError> {
                 Ok(Schedule::default())
             } else {
                 match serde_json::from_str::<Schedule>(&content) {
-                    Ok(schedule) => {
+                    Ok(mut schedule) => {
                         println!(
                             "Successfully loaded {} tasks from schedule {}.",
                             schedule.tasks.len(),
                             path.display()
                         );
+                        schedule.tasks.sort_by_key(|task| task.time);
                         Ok(schedule)
                     }
                     Err(e) => {


### PR DESCRIPTION
closes #43 

It's possible for a person to manually create the .json file, so sort the tasks by date when loading the scheduled tasks.

Also fixed the file task not working in the daemon.