### PR TITLE
feat(cli): Add --internet global CLI flag

### DIFF
--- a/src/cli_setup.rs
+++ b/src/cli_setup.rs
@@ -164,4 +164,7 @@ pub struct Cli {
 
   #[arg(short = 'v', long = "verbose", global = true, help = "Show detailed progress information")]
   pub verbose: bool,
+
+  #[arg(long, global = true, help = "Use internet API instead of local network")]
+  pub internet: bool,
 }

--- a/src/tests/cli_setup_tests.rs
+++ b/src/tests/cli_setup_tests.rs
@@ -371,3 +371,62 @@ fn test_cli_parses_schedule_run_dry_run_short() {
     _ => panic!("Expected Schedule Run command"),
   }
 }
+
+// --- Internet flag CLI parsing tests ---
+
+#[test]
+fn test_cli_parses_internet_flag_before_command() {
+  let cli = Cli::parse_from(["vbl", "--internet", "show", "text", "hello"]);
+  assert!(cli.internet);
+}
+
+#[test]
+fn test_cli_parses_without_internet_flag() {
+  let cli = Cli::parse_from(["vbl", "show", "text", "hello"]);
+  assert!(!cli.internet);
+}
+
+#[test]
+fn test_cli_parses_internet_flag_after_subcommand() {
+  // Global flags can appear after subcommand
+  let cli = Cli::parse_from(["vbl", "show", "--internet", "text", "hello"]);
+  assert!(cli.internet);
+}
+
+#[test]
+fn test_cli_parses_playlist_run_with_internet_flag() {
+  let cli = Cli::parse_from(["vbl", "playlist", "run", "--internet"]);
+  assert!(cli.internet);
+  match cli.command {
+    Command::Playlist {
+      action: PlaylistArgs::Run { .. },
+    } => {},
+    _ => panic!("Expected Playlist Run command"),
+  }
+}
+
+#[test]
+fn test_cli_parses_schedule_run_with_internet_flag() {
+  let cli = Cli::parse_from(["vbl", "schedule", "run", "--internet"]);
+  assert!(cli.internet);
+  match cli.command {
+    Command::Schedule {
+      action: ScheduleArgs::Run { .. },
+    } => {},
+    _ => panic!("Expected Schedule Run command"),
+  }
+}
+
+#[test]
+fn test_cli_parses_playlist_add_with_internet_flag() {
+  let cli = Cli::parse_from(["vbl", "--internet", "playlist", "add", "weather"]);
+  assert!(cli.internet);
+  match cli.command {
+    Command::Playlist {
+      action: PlaylistArgs::Add { widget, .. },
+    } => {
+      assert_eq!(widget, "weather");
+    },
+    _ => panic!("Expected Playlist Add command"),
+  }
+}


### PR DESCRIPTION
## Summary
- Add `--internet` flag to `Cli` struct as a global flag
- Flag is available on all commands (show, playlist, schedule)
- Defaults to false (local transport)

Closes #94

## Test plan
- [x] `vbl --internet show text "hello"` parses with `internet: true`
- [x] `vbl show text "hello"` parses with `internet: false`
- [x] `vbl show --internet text "hello"` works (global flag position)
- [x] `vbl playlist run --internet` parses correctly
- [x] `vbl schedule run --internet` parses correctly
- [x] `vbl --internet playlist add weather` parses correctly
- [x] `cargo test cli_setup` passes (30 tests)
- [x] `vbl --help` shows `--internet` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)