### PR TITLE
Update documentation for internet transport feature (#97)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Vestaboard Local Environment Variables
+# Copy this file to .env and fill in your values
+
+# ===========================================
+# Local API (required for local network access)
+# ===========================================
+# Enable Local API on your Vestaboard: https://docs-v1.vestaboard.com/local
+
+# Your Local API key from the Vestaboard
+LOCAL_API_KEY=your-local-api-key-here
+
+# Local IP address of your Vestaboard (e.g., 192.168.1.100)
+IP_ADDRESS=192.168.x.x
+
+# ===========================================
+# Internet API (optional, for remote access)
+# ===========================================
+# Get your Read/Write API key from the Vestaboard app:
+# Settings > Integrations > Read/Write API
+
+INTERNET_API_KEY=your-read-write-api-key-here
+
+# ===========================================
+# Widget API Keys (optional)
+# ===========================================
+
+# Weather widget - get key from https://www.weatherapi.com/
+WEATHER_API_KEY=your-weather-api-key-here


### PR DESCRIPTION
## Summary

Update user-facing documentation for the internet transport feature.

## Changes

- Add `.env.example` file with all environment variables documented
- Update README.md with:
  - INTERNET_API_KEY in prerequisites section
  - Transport selection priority documentation (CLI flag > config > default)
  - Examples for remote usage with `--internet` flag
  - `transport` config option in configuration table
  - Troubleshooting section for common errors
  - Updated examples section with modern command syntax

## Checklist from Issue

### Update README.md
- [x] Add `INTERNET_API_KEY` to environment variables section
- [x] Add `--internet` flag to CLI usage section
- [x] Add examples for remote usage

### Document config option
- [x] Add `transport` option to config documentation
- [x] Example config with transport option

### Add troubleshooting section
- [x] "INTERNET_API_KEY not set" error
- [x] "LOCAL_API_KEY not set" error
- [x] Network connectivity issues
- [x] HTTP 304 "Message unchanged" explanation

### Update help text
- [x] Verified `vbl --help` is clear
- [x] Verified `vbl show --help` mentions transport

## Verify
- [x] README examples work
- [x] Config example is valid TOML

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)